### PR TITLE
add ability for data aggregation in DataProviders

### DIFF
--- a/gordo_dataset/data_provider/base.py
+++ b/gordo_dataset/data_provider/base.py
@@ -20,8 +20,7 @@ class GordoBaseDataProvider(object):
         train_end_date: datetime,
         tag_list: List[SensorTag],
         dry_run: Optional[bool] = False,
-        resolution: Optional[str] = None,
-        aggregation_method: Optional[str] = None,
+        **kwargs,
     ) -> Iterable[pd.Series]:
         """
         Load the required data as an iterable of series where each
@@ -38,16 +37,8 @@ class GordoBaseDataProvider(object):
         dry_run: Optional[bool]
             Set to true to perform a "dry run" of the loading.
             Up to the implementations to determine what that means.
-        resolution: Optional[str]
-            Time window for datapoints aggregation in "DataProvider".
-            Will be used if "DataProvider" supports such functionality.
-            Used with "aggregation_method" param.
-            Example: "10m" (datapoints aggregated for each 10m: 01:00,01:10,..)
-        aggregation_method: Optional[str]
-            Method for data-aggregation in "DataProvider".
-            Will be used if "DataProvider" supports such functionality.
-            Takes aggregation time-window from "resolution" param.
-            Examples: "avr,", "min", "max" etc.
+        kwargs: Dict
+            With these - additional data might be passed by data_provider.
 
         Returns
         -------

--- a/gordo_dataset/data_provider/base.py
+++ b/gordo_dataset/data_provider/base.py
@@ -20,6 +20,8 @@ class GordoBaseDataProvider(object):
         train_end_date: datetime,
         tag_list: List[SensorTag],
         dry_run: Optional[bool] = False,
+        resolution: Optional[str] = None,
+        aggregation_method: Optional[str] = None,
     ) -> Iterable[pd.Series]:
         """
         Load the required data as an iterable of series where each
@@ -36,6 +38,16 @@ class GordoBaseDataProvider(object):
         dry_run: Optional[bool]
             Set to true to perform a "dry run" of the loading.
             Up to the implementations to determine what that means.
+        resolution: Optional[str]
+            Time window for datapoints aggregation in "DataProvider".
+            Will be used if "DataProvider" supports such functionality.
+            Used with "aggregation_method" param.
+            Example: "10m" (datapoints aggregated for each 10m: 01:00,01:10,..)
+        aggregation_method: Optional[str]
+            Method for data-aggregation in "DataProvider".
+            Will be used if "DataProvider" supports such functionality.
+            Takes aggregation time-window from "resolution" param.
+            Examples: "avr,", "min", "max" etc.
 
         Returns
         -------

--- a/gordo_dataset/data_provider/iroc_reader.py
+++ b/gordo_dataset/data_provider/iroc_reader.py
@@ -60,6 +60,8 @@ class IrocReader(GordoBaseDataProvider):
         train_end_date: datetime,
         tag_list: List[SensorTag],
         dry_run: Optional[bool] = False,
+        resolution: Optional[str] = None,
+        aggregation_method: Optional[str] = None,
     ):
         """
         See GordoBaseDataProvider for documentation

--- a/gordo_dataset/data_provider/iroc_reader.py
+++ b/gordo_dataset/data_provider/iroc_reader.py
@@ -60,8 +60,7 @@ class IrocReader(GordoBaseDataProvider):
         train_end_date: datetime,
         tag_list: List[SensorTag],
         dry_run: Optional[bool] = False,
-        resolution: Optional[str] = None,
-        aggregation_method: Optional[str] = None,
+        **kwargs,
     ):
         """
         See GordoBaseDataProvider for documentation

--- a/gordo_dataset/data_provider/ncs_reader.py
+++ b/gordo_dataset/data_provider/ncs_reader.py
@@ -120,6 +120,8 @@ class NcsReader(GordoBaseDataProvider):
         train_end_date: datetime,
         tag_list: List[SensorTag],
         dry_run: Optional[bool] = False,
+        resolution: Optional[str] = None,
+        aggregation_method: Optional[str] = None,
     ) -> Iterable[pd.Series]:
         """
         See GordoBaseDataProvider for documentation

--- a/gordo_dataset/data_provider/ncs_reader.py
+++ b/gordo_dataset/data_provider/ncs_reader.py
@@ -120,8 +120,7 @@ class NcsReader(GordoBaseDataProvider):
         train_end_date: datetime,
         tag_list: List[SensorTag],
         dry_run: Optional[bool] = False,
-        resolution: Optional[str] = None,
-        aggregation_method: Optional[str] = None,
+        **kwargs,
     ) -> Iterable[pd.Series]:
         """
         See GordoBaseDataProvider for documentation

--- a/gordo_dataset/data_provider/providers.py
+++ b/gordo_dataset/data_provider/providers.py
@@ -40,6 +40,8 @@ def load_series_from_multiple_providers(
     train_end_date: datetime,
     tag_list: typing.List[SensorTag],
     dry_run: typing.Optional[bool] = False,
+    resolution: Optional[str] = None,
+    aggregation_method: Optional[str] = None,
 ) -> typing.Iterable[pd.DataFrame]:
     """
     Loads the tags in `tag_list` using multiple instances of
@@ -81,6 +83,8 @@ def load_series_from_multiple_providers(
                 train_end_date=train_end_date,
                 tag_list=readers_tags,
                 dry_run=dry_run,
+                resolution=resolution,
+                aggregation_method=aggregation_method,
             ):
                 yield series
     logger.debug(
@@ -162,6 +166,8 @@ class DataLakeProvider(GordoBaseDataProvider):
         train_end_date: datetime,
         tag_list: typing.List[SensorTag],
         dry_run: typing.Optional[bool] = False,
+        resolution: Optional[str] = None,
+        aggregation_method: Optional[str] = None,
     ) -> typing.Iterable[pd.Series]:
         """
         See
@@ -177,7 +183,7 @@ class DataLakeProvider(GordoBaseDataProvider):
         data_providers = self._get_sub_dataproviders()
 
         yield from load_series_from_multiple_providers(
-            data_providers, train_start_date, train_end_date, tag_list, dry_run
+            data_providers, train_start_date, train_end_date, tag_list, dry_run, resolution, aggregation_method,
         )
 
     def _adl1_back_compatible_kwarg(
@@ -300,6 +306,8 @@ class InfluxDataProvider(GordoBaseDataProvider):
         train_end_date: datetime,
         tag_list: typing.List[SensorTag],
         dry_run: typing.Optional[bool] = False,
+        resolution: Optional[str] = None,
+        aggregation_method: Optional[str] = None,
     ) -> typing.Iterable[pd.Series]:
         """
         See GordoBaseDataProvider for documentation
@@ -429,6 +437,8 @@ class RandomDataProvider(GordoBaseDataProvider):
         train_end_date: datetime,
         tag_list: typing.List[SensorTag],
         dry_run: typing.Optional[bool] = False,
+        resolution: Optional[str] = None,
+        aggregation_method: Optional[str] = None,
     ) -> typing.Iterable[pd.Series]:
         if dry_run:
             raise NotImplementedError(

--- a/gordo_dataset/data_provider/providers.py
+++ b/gordo_dataset/data_provider/providers.py
@@ -40,8 +40,7 @@ def load_series_from_multiple_providers(
     train_end_date: datetime,
     tag_list: typing.List[SensorTag],
     dry_run: typing.Optional[bool] = False,
-    resolution: Optional[str] = None,
-    aggregation_method: Optional[str] = None,
+    **kwargs,
 ) -> typing.Iterable[pd.DataFrame]:
     """
     Loads the tags in `tag_list` using multiple instances of
@@ -83,8 +82,7 @@ def load_series_from_multiple_providers(
                 train_end_date=train_end_date,
                 tag_list=readers_tags,
                 dry_run=dry_run,
-                resolution=resolution,
-                aggregation_method=aggregation_method,
+                **kwargs,
             ):
                 yield series
     logger.debug(
@@ -166,8 +164,7 @@ class DataLakeProvider(GordoBaseDataProvider):
         train_end_date: datetime,
         tag_list: typing.List[SensorTag],
         dry_run: typing.Optional[bool] = False,
-        resolution: Optional[str] = None,
-        aggregation_method: Optional[str] = None,
+        **kwargs
     ) -> typing.Iterable[pd.Series]:
         """
         See
@@ -183,7 +180,7 @@ class DataLakeProvider(GordoBaseDataProvider):
         data_providers = self._get_sub_dataproviders()
 
         yield from load_series_from_multiple_providers(
-            data_providers, train_start_date, train_end_date, tag_list, dry_run, resolution, aggregation_method,
+            data_providers, train_start_date, train_end_date, tag_list, dry_run, **kwargs,
         )
 
     def _adl1_back_compatible_kwarg(
@@ -281,7 +278,7 @@ class InfluxDataProvider(GordoBaseDataProvider):
                 # importing TimeSeriesDataset, which imports this provider
                 # which would have imported Client via traversal of the __init__
                 # which would then try to import TimeSeriesDataset again.
-                from gordo.client.utils import influx_client_from_uri
+                from gordo_dataset.utils import influx_client_from_uri
 
                 self.influx_client = influx_client_from_uri(  # type: ignore
                     uri,
@@ -306,8 +303,7 @@ class InfluxDataProvider(GordoBaseDataProvider):
         train_end_date: datetime,
         tag_list: typing.List[SensorTag],
         dry_run: typing.Optional[bool] = False,
-        resolution: Optional[str] = None,
-        aggregation_method: Optional[str] = None,
+        **kwargs
     ) -> typing.Iterable[pd.Series]:
         """
         See GordoBaseDataProvider for documentation
@@ -437,8 +433,7 @@ class RandomDataProvider(GordoBaseDataProvider):
         train_end_date: datetime,
         tag_list: typing.List[SensorTag],
         dry_run: typing.Optional[bool] = False,
-        resolution: Optional[str] = None,
-        aggregation_method: Optional[str] = None,
+        **kwargs
     ) -> typing.Iterable[pd.Series]:
         if dry_run:
             raise NotImplementedError(

--- a/gordo_dataset/datasets.py
+++ b/gordo_dataset/datasets.py
@@ -256,6 +256,7 @@ class TimeSeriesDataset(GordoBaseDataset):
             train_start_date=self.train_start_date,
             train_end_date=self.train_end_date,
             tag_list=list(tag_list),
+            resolution=self.resolution,
         )
 
         # Resample if we have a resolution set, otherwise simply join the series.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "gordo-dataset"
-version = "2.1.3"
+version = "2.2.0"
 description = "Gordo datasets and data providers"
 authors = ["Equinor ASA <fg_gpl@equinor.com>"]
 

--- a/tests/data_provider/conftest.py
+++ b/tests/data_provider/conftest.py
@@ -23,6 +23,8 @@ class DummyDataProvider(GordoBaseDataProvider):
         train_end_date: datetime,
         tag_list: List[SensorTag],
         dry_run: Optional[bool] = False,
+        resolution: Optional[str] = None,
+        aggregation_method: Optional[str] = None,
     ) -> Iterable[pd.Series]:
         yield pd.Series()
 

--- a/tests/data_provider/conftest.py
+++ b/tests/data_provider/conftest.py
@@ -23,8 +23,7 @@ class DummyDataProvider(GordoBaseDataProvider):
         train_end_date: datetime,
         tag_list: List[SensorTag],
         dry_run: Optional[bool] = False,
-        resolution: Optional[str] = None,
-        aggregation_method: Optional[str] = None,
+        **kwargs,
     ) -> Iterable[pd.Series]:
         yield pd.Series()
 

--- a/tests/data_provider/test_data_providers.py
+++ b/tests/data_provider/test_data_providers.py
@@ -27,8 +27,7 @@ class MockProducerRegExp(GordoBaseDataProvider):
         train_end_date: datetime,
         tag_list: List[SensorTag],
         dry_run=False,
-        resolution: Optional[str] = None,
-        aggregation_method: Optional[str] = None,
+        **kwargs,
     ) -> Iterable[pd.Series]:
         for tag in tag_list:
             if self.regexp.match(tag.name):

--- a/tests/data_provider/test_data_providers.py
+++ b/tests/data_provider/test_data_providers.py
@@ -1,7 +1,7 @@
 import re
 import unittest
 from datetime import datetime
-from typing import Iterable, List, Pattern, Any
+from typing import Iterable, List, Pattern, Any, Optional
 
 import pandas as pd
 import pytest
@@ -27,6 +27,8 @@ class MockProducerRegExp(GordoBaseDataProvider):
         train_end_date: datetime,
         tag_list: List[SensorTag],
         dry_run=False,
+        resolution: Optional[str] = None,
+        aggregation_method: Optional[str] = None,
     ) -> Iterable[pd.Series]:
         for tag in tag_list:
             if self.regexp.match(tag.name):

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -409,8 +409,7 @@ class MockDataProvider(GordoBaseDataProvider):
         train_end_date: datetime,
         tag_list: List[SensorTag],
         dry_run: Optional[bool] = False,
-        resolution: Optional[str] = None,
-        aggregation_method: Optional[str] = None,
+        **kwargs,
     ) -> Iterable[pd.Series]:
         self.last_tag_list = tag_list
         index = pd.date_range(train_start_date, train_end_date, freq="s")

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -409,6 +409,8 @@ class MockDataProvider(GordoBaseDataProvider):
         train_end_date: datetime,
         tag_list: List[SensorTag],
         dry_run: Optional[bool] = False,
+        resolution: Optional[str] = None,
+        aggregation_method: Optional[str] = None,
     ) -> Iterable[pd.Series]:
         self.last_tag_list = tag_list
         index = pd.date_range(train_start_date, train_end_date, freq="s")


### PR DESCRIPTION
The idea behind this PR is to be able to use data aggregation on the DataProvider side - not to fetch all datapoints and then aggregate it in the Gordo Client.
Example: TS API has ability to aggregate data on its side with mentioned in PR parameters, so Client will fetch 144 points for each tag per day instead of few thousands. 
Len for example in [Latigo](https://github.com/equinor/latigo/blob/master/app/latigo/gordo/data_provider.py#L53) we could use them to pass to TS API.

* backwards-compatibility is kept;
* version 2.2.0.